### PR TITLE
Auto identify user on backend track event

### DIFF
--- a/apps/hub/src/index.ts
+++ b/apps/hub/src/index.ts
@@ -127,7 +127,8 @@ app.post(
     await redisClient?.setEx(redisKey, REDIS_USER_IDENTIFY_EXPIRATION, '1');
 
     try {
-      const response = await identifyUser(context, body, projectId);
+      const userId = await getUserIdFromRequest(context, false);
+      const response = await identifyUser(context, body, projectId, userId);
 
       await redisClient?.del(redisKey);
 

--- a/apps/hub/src/utils/event.ts
+++ b/apps/hub/src/utils/event.ts
@@ -130,7 +130,7 @@ export const trackEvent = async (context: HonoContext, body: EventSchema) => {
     jobId: eventId,
   });
 
-  if (body.userData) {
+  if (body.userData || body?.displayName) {
     await addToQueue(
       updateUserQueue,
       {

--- a/apps/hub/src/utils/event.ts
+++ b/apps/hub/src/utils/event.ts
@@ -111,7 +111,7 @@ export const trackEvent = async (context: HonoContext, body: EventSchema) => {
     reqDisplayName: body?.displayName,
   });
 
-  const evenQueueData = {
+  const eventQueueData = {
     projectId: String(projectId),
     userId: String(userId),
     eventId,
@@ -126,7 +126,7 @@ export const trackEvent = async (context: HonoContext, body: EventSchema) => {
     reqIdentifier: body?.identifier,
     reqDisplayName: body?.displayName,
   };
-  await addToQueue(eventQueue, evenQueueData, {
+  await addToQueue(eventQueue, eventQueueData, {
     jobId: eventId,
   });
 
@@ -137,6 +137,7 @@ export const trackEvent = async (context: HonoContext, body: EventSchema) => {
         projectId: String(projectId),
         userId: String(userId),
         updatedAt: now,
+        displayName: body?.displayName,
         data: body.userData,
       },
       {

--- a/apps/hub/src/utils/session.ts
+++ b/apps/hub/src/utils/session.ts
@@ -1,6 +1,7 @@
+import { SESSION_DURATION_MINUTES } from '@vemetric/common/session';
 import { getRedisClient } from './redis';
 
-const REDIS_SESSION_DURATION = 60 * 30; // 30 mins
+const REDIS_SESSION_DURATION = 60 * SESSION_DURATION_MINUTES;
 
 function getRedisSessionKey(projectId: bigint, userId: bigint) {
   return `sessionid:${projectId}:${userId}`;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -3,6 +3,7 @@ import { logger } from './utils/logger';
 import { initCreateUserWorker } from './workers/create-user-worker';
 import { initDeviceWorker } from './workers/device-worker';
 import { initEmailWorker } from './workers/email-worker';
+import { initEnrichUserWorker } from './workers/enrich-user-worker';
 import { initEventWorker } from './workers/event-worker';
 import { initFirstEventWorker } from './workers/first-event-worker';
 import { initMergeUserWorker } from './workers/merge-user-worker';
@@ -19,6 +20,7 @@ async function main() {
     workers.push(await initSessionWorker());
     workers.push(await initCreateUserWorker());
     workers.push(await initUpdateUserWorker());
+    workers.push(await initEnrichUserWorker());
     workers.push(await initMergeUserWorker());
     workers.push(await initDeviceWorker());
     workers.push(await initEmailWorker());

--- a/apps/worker/src/utils/merge-user.ts
+++ b/apps/worker/src/utils/merge-user.ts
@@ -1,0 +1,128 @@
+import { formatClickhouseDate } from '@vemetric/common/date';
+import { SESSION_DURATION_MINUTES } from '@vemetric/common/session';
+import type { ClickhouseEvent, ClickhouseSession } from 'clickhouse';
+import { clickhouseDateToISO, clickhouseSession } from 'clickhouse';
+
+const SESSION_DURATION_MS = SESSION_DURATION_MINUTES * 60 * 1000;
+
+// Helper function to check if an event time falls within a session (with 30-minute window)
+const eventBelongsToSession = (eventTime: string, session: ClickhouseSession) => {
+  const eventDate = new Date(clickhouseDateToISO(eventTime)).getTime();
+  const sessionStart = new Date(clickhouseDateToISO(session.startedAt)).getTime();
+  const sessionEnd = new Date(clickhouseDateToISO(session.endedAt)).getTime();
+  // Add 30 minutes buffer for session inactivity timeout
+  const sessionStartWithBuffer = sessionStart - SESSION_DURATION_MS;
+  const sessionEndWithBuffer = sessionEnd + SESSION_DURATION_MS;
+  return eventDate >= sessionStartWithBuffer && eventDate <= sessionEndWithBuffer;
+};
+
+interface UserMigrationContext {
+  projectId: bigint;
+  newUserId: bigint;
+  existingEvents: Array<ClickhouseEvent>;
+  oldUserSessions: Array<ClickhouseSession>;
+}
+
+export const reassignExistingSessionsToEvents = async (context: UserMigrationContext) => {
+  const { projectId, newUserId, existingEvents, oldUserSessions } = context;
+
+  const eventTimes = existingEvents.map((e) => new Date(clickhouseDateToISO(e.createdAt)).getTime());
+  const minEventTime = Math.min(...eventTimes);
+  const maxEventTime = Math.max(...eventTimes);
+
+  const searchStartTime = new Date(minEventTime - SESSION_DURATION_MS);
+  const searchEndTime = new Date(maxEventTime + SESSION_DURATION_MS);
+
+  // Query only relevant sessions from the new user within this time range
+  const newUserSessions = await clickhouseSession.findByUserIdInTimeRange(
+    projectId,
+    newUserId,
+    searchStartTime,
+    searchEndTime,
+  );
+
+  // Create a map of sessions to migrate and session ID mappings
+  const oldSessionIdsToMigrate = new Set<string>();
+  const sessionIdMapping = new Map<string, string>(); // old session id -> new session id
+  const sessionTimeUpdates = new Map<
+    string,
+    { changedStart: boolean; startedAt: Date; endedAt: Date; duration: number }
+  >(); // track time updates for existing sessions
+
+  // we iterate through all the events and see if we can find a new session to assign it to
+  for (const event of existingEvents) {
+    for (const newSession of newUserSessions) {
+      if (!eventBelongsToSession(event.createdAt, newSession)) {
+        continue;
+      }
+
+      sessionIdMapping.set(event.sessionId, newSession.id);
+
+      // Update the session time bounds if needed
+      const eventTime = new Date(clickhouseDateToISO(event.createdAt)).getTime();
+      const existing = sessionTimeUpdates.get(newSession.id);
+
+      if (existing) {
+        const currentStart = existing.startedAt.getTime();
+        const currentEnd = existing.endedAt.getTime();
+        const newStart = Math.min(currentStart, eventTime);
+        const newEnd = Math.max(currentEnd, eventTime);
+
+        sessionTimeUpdates.set(newSession.id, {
+          changedStart: existing.changedStart || newStart !== currentStart,
+          startedAt: new Date(newStart),
+          endedAt: new Date(newEnd),
+          duration: Math.round((newEnd - newStart) / 1000),
+        });
+      } else {
+        const currentStart = new Date(clickhouseDateToISO(newSession.startedAt)).getTime();
+        const currentEnd = new Date(clickhouseDateToISO(newSession.endedAt)).getTime();
+        const newStart = Math.min(currentStart, eventTime);
+        const newEnd = Math.max(currentEnd, eventTime);
+
+        if (newStart < currentStart || newEnd > currentEnd) {
+          sessionTimeUpdates.set(newSession.id, {
+            changedStart: newStart !== currentStart,
+            startedAt: new Date(newStart),
+            endedAt: new Date(newEnd),
+            duration: Math.round((newEnd - newStart) / 1000),
+          });
+        }
+      }
+      break;
+    }
+
+    // no new session found, we just keep the old session
+    oldSessionIdsToMigrate.add(event.sessionId);
+  }
+
+  const oldSessionsToMigrate = Array.from(oldSessionIdsToMigrate)
+    .map((sessionId) => {
+      const session = oldUserSessions.find((s) => s.id === sessionId);
+      return session;
+    })
+    .filter((session) => session !== undefined);
+
+  const sessionsWithTimeUpdates: Array<ClickhouseSession> = [];
+  const newUserSessionsToDelete: Array<ClickhouseSession> = [];
+  // Update the new users' sessions where the times have changed
+  if (sessionTimeUpdates.size > 0) {
+    sessionTimeUpdates.forEach((timeUpdate, sessionId) => {
+      const session = newUserSessions.find((s) => s.id === sessionId);
+      if (session) {
+        if (timeUpdate.changedStart) {
+          // the start time has changed, we delete the session because it counts as a new one
+          newUserSessionsToDelete.push(session);
+        }
+        sessionsWithTimeUpdates.push({
+          ...session,
+          duration: timeUpdate.duration,
+          startedAt: formatClickhouseDate(timeUpdate.startedAt),
+          endedAt: formatClickhouseDate(timeUpdate.endedAt),
+        });
+      }
+    });
+  }
+
+  return { sessionsWithTimeUpdates, newUserSessionsToDelete, oldSessionsToMigrate, sessionIdMapping };
+};

--- a/apps/worker/src/utils/user.ts
+++ b/apps/worker/src/utils/user.ts
@@ -1,4 +1,5 @@
 import type { UpdateUserDataModel } from '@vemetric/queues/update-user-queue';
+import type { ClickhouseEvent } from 'clickhouse';
 
 export const getUpdatedUserData = (existingUserData: object, newUserData: UpdateUserDataModel) => {
   const { set, setOnce, unset } = newUserData ?? {};
@@ -11,4 +12,32 @@ export const getUpdatedUserData = (existingUserData: object, newUserData: Update
   }
 
   return updatedUserData;
+};
+
+export const getUserFirstPageViewData = (firstPageView: ClickhouseEvent | null) => {
+  if (!firstPageView) {
+    return {};
+  }
+
+  return {
+    firstSeenAt: firstPageView.createdAt,
+    countryCode: firstPageView.countryCode,
+    city: firstPageView.city,
+    initialDeviceId: firstPageView.deviceId,
+    userAgent: firstPageView.userAgent,
+    referrer: firstPageView.referrer,
+    referrerUrl: firstPageView.referrerUrl,
+    referrerType: firstPageView.referrerType,
+
+    origin: firstPageView.origin,
+    pathname: firstPageView.pathname,
+    urlHash: firstPageView.urlHash,
+    queryParams: firstPageView.queryParams,
+
+    utmSource: firstPageView.utmSource,
+    utmMedium: firstPageView.utmMedium,
+    utmCampaign: firstPageView.utmCampaign,
+    utmContent: firstPageView.utmContent,
+    utmTerm: firstPageView.utmTerm,
+  };
 };

--- a/apps/worker/src/workers/enrich-user-worker.ts
+++ b/apps/worker/src/workers/enrich-user-worker.ts
@@ -1,0 +1,56 @@
+import { formatClickhouseDate } from '@vemetric/common/date';
+import type { EnrichUserQueueProps } from '@vemetric/queues/enrich-user-queue';
+import { enrichUserQueueName } from '@vemetric/queues/queue-names';
+import { Worker } from 'bullmq';
+import { clickhouseEvent, clickhouseUser } from 'clickhouse';
+import { logger } from '../utils/logger';
+import { getUserFirstPageViewData } from '../utils/user';
+
+export async function initEnrichUserWorker() {
+  return new Worker<EnrichUserQueueProps>(
+    enrichUserQueueName,
+    async (job) => {
+      const { projectId: _projectId, userId: _userId } = job.data;
+      const projectId = BigInt(_projectId);
+      const userId = BigInt(_userId);
+
+      // Check if the user exists and is missing attribution data
+      const existingUser = await clickhouseUser.findById(projectId, userId);
+      if (!existingUser) {
+        logger.warn({ projectId: _projectId, userId: _userId }, 'User not found for enrichment');
+        return;
+      }
+
+      // Check if user already has attribution data (origin is a good indicator)
+      if (existingUser.origin) {
+        return;
+      }
+
+      // Fetch the first page view to get attribution data
+      const firstPageView = await clickhouseEvent.getFirstPageViewByUserId(projectId, userId);
+      if (!firstPageView) {
+        return;
+      }
+
+      // Insert a new row with enriched attribution data
+      await clickhouseUser.insert([
+        {
+          ...existingUser,
+          updatedAt: formatClickhouseDate(new Date()),
+          ...getUserFirstPageViewData(firstPageView),
+        },
+      ]);
+
+      logger.info({ projectId: _projectId, userId: _userId }, 'User enrichment completed');
+    },
+    {
+      connection: {
+        url: process.env.REDIS_URL,
+      },
+      concurrency: 10,
+      removeOnComplete: {
+        count: 1000,
+      },
+    },
+  );
+}

--- a/apps/worker/src/workers/enrich-user-worker.ts
+++ b/apps/worker/src/workers/enrich-user-worker.ts
@@ -14,14 +14,13 @@ export async function initEnrichUserWorker() {
       const projectId = BigInt(_projectId);
       const userId = BigInt(_userId);
 
-      // Check if the user exists and is missing attribution data
       const existingUser = await clickhouseUser.findById(projectId, userId);
       if (!existingUser) {
         logger.warn({ projectId: _projectId, userId: _userId }, 'User not found for enrichment');
         return;
       }
 
-      // Check if user already has attribution data (origin is a good indicator)
+      // Check if user already has attribution data (origin is a good indicator as it comes from a page view)
       if (existingUser.origin) {
         return;
       }

--- a/apps/worker/src/workers/event-worker.ts
+++ b/apps/worker/src/workers/event-worker.ts
@@ -35,7 +35,7 @@ export async function initEventWorker() {
 
       const user: ClickhouseUser | null = await clickhouseUser.findById(projectId, userId);
       const userIdentifier = user?.identifier ?? reqIdentifier;
-      const userDisplayName = user?.displayName ?? reqDisplayName;
+      const userDisplayName = reqDisplayName ?? user?.displayName;
 
       const userAgent = headers['user-agent'];
       const referrer = await getReferrerFromHeaders(projectId, headers);

--- a/apps/worker/src/workers/merge-user-worker.ts
+++ b/apps/worker/src/workers/merge-user-worker.ts
@@ -1,33 +1,11 @@
-import { formatClickhouseDate } from '@vemetric/common/date';
-import { SESSION_DURATION_MINUTES } from '@vemetric/common/session';
 import type { MergeUserQueueProps } from '@vemetric/queues/merge-user-queue';
 import { mergeUserQueueName } from '@vemetric/queues/queue-names';
 import { Worker } from 'bullmq';
-import type { ClickhouseSession } from 'clickhouse';
-import {
-  clickhouseDateToISO,
-  clickhouseDevice,
-  clickhouseEvent,
-  clickhouseSession,
-  clickhouseUser,
-  getDeviceId,
-} from 'clickhouse';
+import { clickhouseDevice, clickhouseEvent, clickhouseSession, clickhouseUser, getDeviceId } from 'clickhouse';
 import { dbUserIdentificationMap } from 'database';
 import { insertDeviceIfNotExists } from '../utils/device';
 import { logger } from '../utils/logger';
-
-const SESSION_DURATION_MS = SESSION_DURATION_MINUTES * 60 * 1000;
-
-// Helper function to check if an event time falls within a session (with 30-minute window)
-const eventBelongsToSession = (eventTime: string, session: ClickhouseSession) => {
-  const eventDate = new Date(clickhouseDateToISO(eventTime)).getTime();
-  const sessionStart = new Date(clickhouseDateToISO(session.startedAt)).getTime();
-  const sessionEnd = new Date(clickhouseDateToISO(session.endedAt)).getTime();
-  // Add 30 minutes buffer for session inactivity timeout
-  const sessionStartWithBuffer = sessionStart - SESSION_DURATION_MS;
-  const sessionEndWithBuffer = sessionEnd + SESSION_DURATION_MS;
-  return eventDate >= sessionStartWithBuffer && eventDate <= sessionEndWithBuffer;
-};
+import { reassignExistingSessionsToEvents } from '../utils/merge-user';
 
 export async function initMergeUserWorker() {
   return new Worker<MergeUserQueueProps>(
@@ -58,161 +36,73 @@ export async function initMergeUserWorker() {
         logger.error({ err }, 'Error deleting devices');
       }
 
-      // Get all sessions and events from the old user
-      const oldUserSessions = await clickhouseSession.findByUserId(projectId, oldUserId);
       const existingEvents = await clickhouseEvent.findByUserId(projectId, oldUserId);
-
-      if (existingEvents.length > 0) {
-        const eventTimes = existingEvents.map((e) => new Date(clickhouseDateToISO(e.createdAt)).getTime());
-        const minEventTime = Math.min(...eventTimes);
-        const maxEventTime = Math.max(...eventTimes);
-
-        const searchStartTime = new Date(minEventTime - SESSION_DURATION_MS);
-        const searchEndTime = new Date(maxEventTime + SESSION_DURATION_MS);
-
-        // Query only relevant sessions from the new user within this time range
-        const newUserSessions = await clickhouseSession.findByUserIdInTimeRange(
+      if (existingEvents.length <= 0) {
+        return;
+      }
+      const oldUserSessions = await clickhouseSession.findByUserId(projectId, oldUserId);
+      const { sessionsWithTimeUpdates, newUserSessionsToDelete, oldSessionsToMigrate, sessionIdMapping } =
+        await reassignExistingSessionsToEvents({
           projectId,
           newUserId,
-          searchStartTime,
-          searchEndTime,
-        );
+          existingEvents,
+          oldUserSessions,
+        });
 
-        // Create a map of sessions to migrate and session ID mappings
-        const oldSessionIdsToMigrate = new Set<string>();
-        const sessionIdMapping = new Map<string, string>(); // old session id -> new session id
-        const sessionTimeUpdates = new Map<
-          string,
-          { changedStart: boolean; startedAt: Date; endedAt: Date; duration: number }
-        >(); // track time updates for existing sessions
-
-        // we iterate through all the events and see if we can find a new session to assign it to
-        for (const event of existingEvents) {
-          for (const newSession of newUserSessions) {
-            if (!eventBelongsToSession(event.createdAt, newSession)) {
-              continue;
-            }
-
-            sessionIdMapping.set(event.sessionId, newSession.id);
-
-            // Update the session time bounds if needed
-            const eventTime = new Date(clickhouseDateToISO(event.createdAt)).getTime();
-            const existing = sessionTimeUpdates.get(newSession.id);
-
-            if (existing) {
-              const currentStart = existing.startedAt.getTime();
-              const currentEnd = existing.endedAt.getTime();
-              const newStart = Math.min(currentStart, eventTime);
-              const newEnd = Math.max(currentEnd, eventTime);
-
-              sessionTimeUpdates.set(newSession.id, {
-                changedStart: existing.changedStart || newStart !== currentStart,
-                startedAt: new Date(newStart),
-                endedAt: new Date(newEnd),
-                duration: Math.round((newEnd - newStart) / 1000),
-              });
-            } else {
-              const currentStart = new Date(clickhouseDateToISO(newSession.startedAt)).getTime();
-              const currentEnd = new Date(clickhouseDateToISO(newSession.endedAt)).getTime();
-              const newStart = Math.min(currentStart, eventTime);
-              const newEnd = Math.max(currentEnd, eventTime);
-
-              if (newStart < currentStart || newEnd > currentEnd) {
-                sessionTimeUpdates.set(newSession.id, {
-                  changedStart: newStart !== currentStart,
-                  startedAt: new Date(newStart),
-                  endedAt: new Date(newEnd),
-                  duration: Math.round((newEnd - newStart) / 1000),
-                });
-              }
-            }
-            break;
-          }
-
-          // no new session found, we just keep the old session
-          oldSessionIdsToMigrate.add(event.sessionId);
-        }
-
-        const newUserSessionsToDelete: Array<ClickhouseSession> = [];
-        // Update the new users' sessions where the times have changed
-        if (sessionTimeUpdates.size > 0) {
-          const sessionsToUpdate: Array<ClickhouseSession> = [];
-          sessionTimeUpdates.forEach((timeUpdate, sessionId) => {
-            const session = newUserSessions.find((s) => s.id === sessionId);
-            if (session) {
-              if (timeUpdate.changedStart) {
-                // the start time has changed, we delete the session because it counts as a new one
-                newUserSessionsToDelete.push(session);
-              }
-              sessionsToUpdate.push({
-                ...session,
-                duration: timeUpdate.duration,
-                startedAt: formatClickhouseDate(timeUpdate.startedAt),
-                endedAt: formatClickhouseDate(timeUpdate.endedAt),
-              });
-            }
-          });
-          if (sessionsToUpdate.length > 0) {
-            await clickhouseSession.insert(sessionsToUpdate);
-          }
-        }
-
-        // Migrate old sessions that still have events
-        const oldSessionsToMigrate = Array.from(oldSessionIdsToMigrate)
-          .map((sessionId) => {
-            const session = oldUserSessions.find((s) => s.id === sessionId);
-            return session;
-          })
-          .filter((session) => session !== undefined);
-        if (oldSessionsToMigrate.length > 0) {
-          await clickhouseSession.insert(
-            oldSessionsToMigrate.map((session) => {
-              return {
-                ...session,
-                userId: newUserId,
-                userIdentifier: existingUser.identifier,
-                userDisplayName: displayName ?? existingUserClickhouse?.displayName,
-              };
-            }),
-          );
-        }
-
-        // Delete all old sessions + new sessions that have updated their start time
-        if (oldUserSessions.length > 0 || newUserSessionsToDelete.length > 0) {
-          await clickhouseSession.delete(
-            [...oldUserSessions, ...newUserSessionsToDelete].map((session) => ({ ...session, id: '' })),
-          );
-        }
-
-        // Delete all old events
-        await clickhouseEvent.delete(existingEvents.map((event) => ({ ...event, sessionId: '' })));
-
-        const insertedDeviceIds: bigint[] = [];
-        for (const event of existingEvents) {
-          const deviceId = getDeviceId(projectId, newUserId, event);
-          if (!insertedDeviceIds.includes(deviceId)) {
-            await insertDeviceIfNotExists(projectId, newUserId, deviceId, event);
-            insertedDeviceIds.push(deviceId);
-          }
-        }
-
-        // Update all events with proper session assignment
-        await clickhouseEvent.insert(
-          existingEvents.map((event) => {
-            const deviceId = getDeviceId(projectId, newUserId, event);
-
+      // Migrate old sessions that still have events assigned to the new user
+      if (oldSessionsToMigrate.length > 0) {
+        await clickhouseSession.insert(
+          oldSessionsToMigrate.map((session) => {
             return {
-              ...event,
-              projectId,
+              ...session,
               userId: newUserId,
-              deviceId,
-              sessionId: sessionIdMapping.get(event.sessionId) ?? event.sessionId,
-              userDisplayName: displayName ?? existingUserClickhouse?.displayName,
               userIdentifier: existingUser.identifier,
+              userDisplayName: displayName ?? existingUserClickhouse?.displayName,
             };
           }),
         );
       }
+
+      // update (and insert) sessions from the new user where times have changed
+      if (sessionsWithTimeUpdates.length > 0) {
+        await clickhouseSession.insert(sessionsWithTimeUpdates);
+      }
+
+      // Delete all sessions from the old user and also sessions from the new user that have updated their start time (because that's part of the primary key in clickhouse)
+      if (oldUserSessions.length > 0 || newUserSessionsToDelete.length > 0) {
+        await clickhouseSession.delete(
+          [...oldUserSessions, ...newUserSessionsToDelete].map((session) => ({ ...session, id: '' })),
+        );
+      }
+
+      // Delete all old events
+      await clickhouseEvent.delete(existingEvents.map((event) => ({ ...event, sessionId: '' })));
+
+      const insertedDeviceIds: bigint[] = [];
+      for (const event of existingEvents) {
+        const deviceId = getDeviceId(projectId, newUserId, event);
+        if (!insertedDeviceIds.includes(deviceId)) {
+          await insertDeviceIfNotExists(projectId, newUserId, deviceId, event);
+          insertedDeviceIds.push(deviceId);
+        }
+      }
+
+      // Add all events to the new user with proper session and device assignment
+      await clickhouseEvent.insert(
+        existingEvents.map((event) => {
+          const deviceId = getDeviceId(projectId, newUserId, event);
+
+          return {
+            ...event,
+            projectId,
+            userId: newUserId,
+            deviceId,
+            sessionId: sessionIdMapping.get(event.sessionId) ?? event.sessionId,
+            userDisplayName: displayName ?? existingUserClickhouse?.displayName,
+            userIdentifier: existingUser.identifier,
+          };
+        }),
+      );
     },
     {
       connection: {

--- a/apps/worker/src/workers/merge-user-worker.ts
+++ b/apps/worker/src/workers/merge-user-worker.ts
@@ -1,10 +1,26 @@
+import { formatClickhouseDate } from '@vemetric/common/date';
+import { SESSION_DURATION_MINUTES } from '@vemetric/common/session';
 import type { MergeUserQueueProps } from '@vemetric/queues/merge-user-queue';
 import { mergeUserQueueName } from '@vemetric/queues/queue-names';
 import { Worker } from 'bullmq';
+import type { ClickhouseSession } from 'clickhouse';
 import { clickhouseDevice, clickhouseEvent, clickhouseSession, clickhouseUser, getDeviceId } from 'clickhouse';
 import { dbUserIdentificationMap } from 'database';
 import { insertDeviceIfNotExists } from '../utils/device';
 import { logger } from '../utils/logger';
+
+const SESSION_DURATION_MS = SESSION_DURATION_MINUTES * 60 * 1000;
+
+// Helper function to check if an event time falls within a session (with 30-minute window)
+const eventBelongsToSession = (eventTime: string, session: ClickhouseSession) => {
+  const eventDate = new Date(eventTime).getTime();
+  const sessionStart = new Date(session.startedAt).getTime();
+  const sessionEnd = new Date(session.endedAt).getTime();
+  // Add 30 minutes buffer for session inactivity timeout
+  const sessionStartWithBuffer = sessionStart - SESSION_DURATION_MS;
+  const sessionEndWithBuffer = sessionEnd + SESSION_DURATION_MS;
+  return eventDate >= sessionStartWithBuffer && eventDate <= sessionEndWithBuffer;
+};
 
 export async function initMergeUserWorker() {
   return new Worker<MergeUserQueueProps>(
@@ -35,23 +51,121 @@ export async function initMergeUserWorker() {
         logger.error({ err }, 'Error deleting devices');
       }
 
-      // update all sessions to the new user id, and delete the old ones
-      const existingSessions = await clickhouseSession.findByUserId(projectId, oldUserId);
-      if (existingSessions.length > 0) {
-        await clickhouseSession.insert(
-          existingSessions.map((session) => ({
-            ...session,
-            userId: newUserId,
-            userIdentifier: existingUser.identifier,
-            userDisplayName: displayName ?? existingUserClickhouse?.displayName,
-          })),
-        );
-        await clickhouseSession.delete(existingSessions.map((session) => ({ ...session, id: '' })));
-      }
-
-      // update all events to the new user id, and delete the old ones, also insert the corresponding devices for the new user if they don't exist yet
+      // Get all sessions and events from the old user
+      const oldUserSessions = await clickhouseSession.findByUserId(projectId, oldUserId);
       const existingEvents = await clickhouseEvent.findByUserId(projectId, oldUserId);
+
       if (existingEvents.length > 0) {
+        const eventTimes = existingEvents.map((e) => new Date(e.createdAt).getTime());
+        const minEventTime = Math.min(...eventTimes);
+        const maxEventTime = Math.max(...eventTimes);
+
+        const searchStartTime = new Date(minEventTime - SESSION_DURATION_MS);
+        const searchEndTime = new Date(maxEventTime + SESSION_DURATION_MS);
+
+        // Query only relevant sessions from the new user within this time range
+        const newUserSessions = await clickhouseSession.findByUserIdInTimeRange(
+          projectId,
+          newUserId,
+          searchStartTime,
+          searchEndTime,
+        );
+
+        // Create a map of sessions to migrate and session ID mappings
+        const oldSessionIdsToMigrate = new Set<string>();
+        const sessionIdMapping = new Map<string, string>(); // old session id -> new session id
+        const sessionTimeUpdates = new Map<string, { startedAt: Date; endedAt: Date; duration: number }>(); // track time updates for existing sessions
+
+        // we iterate through all the events and see if we can find a new session to assign it to
+        for (const event of existingEvents) {
+          for (const newSession of newUserSessions) {
+            if (!eventBelongsToSession(event.createdAt, newSession)) {
+              continue;
+            }
+
+            sessionIdMapping.set(event.sessionId, newSession.id);
+
+            // Update the session time bounds if needed
+            const eventTime = new Date(event.createdAt).getTime();
+            const existing = sessionTimeUpdates.get(newSession.id);
+
+            if (existing) {
+              const currentStart = existing.startedAt.getTime();
+              const currentEnd = existing.endedAt.getTime();
+              const newStart = Math.min(currentStart, eventTime);
+              const newEnd = Math.max(currentEnd, eventTime);
+
+              sessionTimeUpdates.set(newSession.id, {
+                startedAt: new Date(newStart),
+                endedAt: new Date(newEnd),
+                duration: Math.round((newEnd - newStart) / 1000),
+              });
+            } else {
+              const currentStart = new Date(newSession.startedAt).getTime();
+              const currentEnd = new Date(newSession.endedAt).getTime();
+              const newStart = Math.min(currentStart, eventTime);
+              const newEnd = Math.max(currentEnd, eventTime);
+
+              if (newStart < currentStart || newEnd > currentEnd) {
+                sessionTimeUpdates.set(newSession.id, {
+                  startedAt: new Date(newStart),
+                  endedAt: new Date(newEnd),
+                  duration: Math.round((newEnd - newStart) / 1000),
+                });
+              }
+            }
+            break;
+          }
+
+          // no new session found, we just keep the old session
+          oldSessionIdsToMigrate.add(event.sessionId);
+        }
+
+        // Update the new users' sessions where the times have changed
+        if (sessionTimeUpdates.size > 0) {
+          const sessionsToUpdate: Array<ClickhouseSession> = [];
+          sessionTimeUpdates.forEach((timeUpdate, sessionId) => {
+            const session = newUserSessions.find((s) => s.id === sessionId);
+            if (session) {
+              sessionsToUpdate.push({
+                ...session,
+                duration: timeUpdate.duration,
+                startedAt: formatClickhouseDate(timeUpdate.startedAt),
+                endedAt: formatClickhouseDate(timeUpdate.endedAt),
+              });
+            }
+          });
+          if (sessionsToUpdate.length > 0) {
+            await clickhouseSession.insert(sessionsToUpdate);
+          }
+        }
+
+        // Migrate old sessions that still have events
+        const oldSessionsToMigrate = Array.from(oldSessionIdsToMigrate)
+          .map((sessionId) => {
+            const session = oldUserSessions.find((s) => s.id === sessionId);
+            return session;
+          })
+          .filter((session) => session !== undefined);
+        if (oldSessionsToMigrate.length > 0) {
+          await clickhouseSession.insert(
+            oldSessionsToMigrate.map((session) => {
+              return {
+                ...session,
+                userId: newUserId,
+                userIdentifier: existingUser.identifier,
+                userDisplayName: displayName ?? existingUserClickhouse?.displayName,
+              };
+            }),
+          );
+        }
+
+        // Delete all old sessions
+        if (oldUserSessions.length > 0) {
+          await clickhouseSession.delete(oldUserSessions.map((session) => ({ ...session, id: '' })));
+        }
+
+        // Delete all old events
         await clickhouseEvent.delete(existingEvents.map((event) => ({ ...event, sessionId: '' })));
 
         const insertedDeviceIds: bigint[] = [];
@@ -63,6 +177,7 @@ export async function initMergeUserWorker() {
           }
         }
 
+        // Update all events with proper session assignment
         await clickhouseEvent.insert(
           existingEvents.map((event) => {
             const deviceId = getDeviceId(projectId, newUserId, event);
@@ -72,6 +187,7 @@ export async function initMergeUserWorker() {
               projectId,
               userId: newUserId,
               deviceId,
+              sessionId: sessionIdMapping.get(event.sessionId) ?? event.sessionId,
               userDisplayName: displayName ?? existingUserClickhouse?.displayName,
               userIdentifier: existingUser.identifier,
             };

--- a/packages/common/src/session.ts
+++ b/packages/common/src/session.ts
@@ -1,0 +1,1 @@
+export const SESSION_DURATION_MINUTES = 30;

--- a/packages/queues/src/enrich-user-queue.ts
+++ b/packages/queues/src/enrich-user-queue.ts
@@ -1,0 +1,12 @@
+import { Queue } from 'bullmq';
+import { enrichUserQueueName } from './queue-names';
+import { defaultQueueConnection } from './queue-utils';
+
+export interface EnrichUserQueueProps {
+  projectId: string;
+  userId: string;
+}
+
+export const enrichUserQueue = new Queue<EnrichUserQueueProps>(enrichUserQueueName, {
+  connection: defaultQueueConnection,
+});

--- a/packages/queues/src/queue-names.ts
+++ b/packages/queues/src/queue-names.ts
@@ -1,5 +1,6 @@
 export const createDeviceQueueName = 'create-device';
 export const createUserQueueName = 'create-user';
+export const enrichUserQueueName = 'enrich-user';
 export const eventQueueName = 'event';
 export const mergeUserQueueName = 'merge-user';
 export const sessionQueueName = 'session';


### PR DESCRIPTION
As described in this issue, atm you need to identify a user from the frontend first before tracking an event via one of the Backend SDKs (or the API): https://github.com/vemetric/vemetric-go/issues/7

With this PR, users that haven't identified yet, will automatically be identified when first tracking an event from the backend.

Thanks to the whole user migration logic that was already in place, all the events of the user will be merged together correctly even when the frontend identifies afterwards, we now just have some improvements with correct assignment of events to existing sessions.

Also when the frontend identification happens after the backend identification, the user data will be enriched with more informations we only can track from a browser (the users location, device, browser, ...)