### PR TITLE
feat(webapp): display query parameters in URL and separate Params section

### DIFF
--- a/apps/webapp/src/components/pages/user/event-card.tsx
+++ b/apps/webapp/src/components/pages/user/event-card.tsx
@@ -50,7 +50,7 @@ export const EventCard = ({ event, lastPageViewDate }: Props) => {
   } else if (event.name === '$$outboundLink') {
     displayName = (event.customData?.href as string) ?? 'Outbound Link';
   }
-  console.log(event);
+
   return (
     <Card.Root key={event.id} overflow="hidden" data-event-card>
       <Tooltip

--- a/apps/webapp/src/components/pages/user/event-card.tsx
+++ b/apps/webapp/src/components/pages/user/event-card.tsx
@@ -9,6 +9,7 @@ import { OsIcon } from '@/components/os-icon';
 import { Tooltip } from '@/components/ui/tooltip';
 import { dateTimeFormatter } from '@/utils/date-time-formatter';
 import { RenderAttributeValue } from './render-attribute-value';
+import { formatQueryParams } from '@/utils/url';
 
 interface Props {
   event: {
@@ -19,6 +20,7 @@ interface Props {
     urlHash?: string;
     createdAt: string;
     customData: Record<string, any>;
+    queryParams?: Record<string, any>;
     clientName?: string;
     clientVersion?: string;
     osName?: string;
@@ -48,7 +50,7 @@ export const EventCard = ({ event, lastPageViewDate }: Props) => {
   } else if (event.name === '$$outboundLink') {
     displayName = (event.customData?.href as string) ?? 'Outbound Link';
   }
-
+  console.log(event);
   return (
     <Card.Root key={event.id} overflow="hidden" data-event-card>
       <Tooltip
@@ -98,16 +100,45 @@ export const EventCard = ({ event, lastPageViewDate }: Props) => {
               </Box>
               {isPageView && (
                 <Fragment>
+                  {/* URL section */}
                   <Box fontWeight="semibold" opacity={0.6}>
                     URL
                   </Box>
                   <Box fontWeight="medium" textAlign="right" truncate>
                     <RenderAttributeValue
-                      value={(event.origin ?? '') + (event.pathname ?? '') + (event.urlHash ?? '')}
+                      value={
+                        (event.origin ?? '') +
+                        (event.pathname ?? '') +
+                        formatQueryParams(event.queryParams ?? {}) +
+                        (event.urlHash ?? '')
+                      }
                     />
                   </Box>
+
+                  {/* Params section (same query string in blue small text) */}
+                  {event.queryParams && Object.keys(event.queryParams).length > 0 && (
+                    <Fragment>
+                      <Box fontWeight="semibold" opacity={0.6} mt={2}>
+                        Params
+                      </Box>
+                      <Box fontWeight="medium" textAlign="right" truncate>
+                        <Text
+                          as="span"
+                          fontSize="sm"
+                          color="blue.600"
+                          fontFamily="mono"
+                          whiteSpace="nowrap"
+                          overflow="hidden"
+                          textOverflow="ellipsis"
+                        >
+                          {formatQueryParams(event.queryParams)}
+                        </Text>
+                      </Box>
+                    </Fragment>
+                  )}
                 </Fragment>
               )}
+
               {Object.entries(event.customData)
                 .sort((a, b) => a[0].localeCompare(b[0]))
                 .map(([key, value]) => (

--- a/apps/webapp/src/components/pages/user/event-card.tsx
+++ b/apps/webapp/src/components/pages/user/event-card.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, Flex, Card, SimpleGrid, useBreakpointValue, Span } from '@chakra-ui/react';
+import { Box, Text, Flex, Card, SimpleGrid, useBreakpointValue, Span, Tag } from '@chakra-ui/react';
 import { isEntityUnknown } from '@vemetric/common/event';
 import { motion } from 'motion/react';
 import { Fragment, useState } from 'react';
@@ -115,25 +115,40 @@ export const EventCard = ({ event, lastPageViewDate }: Props) => {
                     />
                   </Box>
 
-                  {/* Params section (same query string in blue small text) */}
+                  {/* Params section */}
                   {event.queryParams && Object.keys(event.queryParams).length > 0 && (
                     <Fragment>
-                      <Box fontWeight="semibold" opacity={0.6} mt={2}>
+                      <Box fontWeight="semibold" opacity={0.6}>
                         Params
                       </Box>
-                      <Box fontWeight="medium" textAlign="right" truncate>
-                        <Text
-                          as="span"
-                          fontSize="sm"
-                          color="blue.600"
-                          fontFamily="mono"
-                          whiteSpace="nowrap"
-                          overflow="hidden"
-                          textOverflow="ellipsis"
-                        >
-                          {formatQueryParams(event.queryParams)}
-                        </Text>
-                      </Box>
+                      <Flex direction="column" align="flex-end" gap={1.5} mt={1}>
+                        {Object.entries(event.queryParams).map(([key, value]) => (
+                          <Tag.Root
+                            key={key}
+                            colorPalette="blue"
+                            size="sm"
+                            borderRadius="md"
+                            fontFamily="mono"
+                            px={2}
+                            py={0.5}
+                            maxW="100%"
+                            overflow="hidden"
+                            whiteSpace="nowrap"
+                            textOverflow="ellipsis"
+                          >
+                            <Tag.Label
+                              truncate
+                              whiteSpace="nowrap"
+                              textOverflow="ellipsis"
+                              overflow="hidden"
+                              display="block"
+                              title={`${key} = ${String(value)}`}
+                            >
+                              {key} = {String(value)}
+                            </Tag.Label>
+                          </Tag.Root>
+                        ))}
+                      </Flex>
                     </Fragment>
                   )}
                 </Fragment>

--- a/apps/webapp/src/utils/url.ts
+++ b/apps/webapp/src/utils/url.ts
@@ -30,3 +30,12 @@ export function getBackendUrl() {
 export function getHubUrl() {
   return getUrl('hub');
 }
+
+export function formatQueryParams(params: Record<string, any>): string {
+  const entries = Object.entries(params);
+  if (entries.length === 0) return '';
+  const queryString = entries
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+  return `?${queryString}`;
+}


### PR DESCRIPTION
## **Display Query Parameters in `event-card`**

### **Description**

This PR improves the `event-card` component on the Users page by making query parameters visible for pageview events, enhancing clarity and debugging.

### **Changes**

* The **URL now includes query parameters inline**, e.g.:

```
https://app.vemetric.localhost:4050/p/*/events?t=24hrs&filter=active&sort=asc
```

* Added a **separate “Params” section** below the URL showing the same query string in **small blue monospace text** for easy reference.
* The Params section **only renders when query parameters exist**.
* Styling is consistent with other fields (`customData`) in the EventCard.

### **Before**

* URL displayed only `origin + pathname + urlHash`.
* Query parameters were not visible anywhere.

### **After**

* URL displays the full path with query parameters included.
* Params section visually highlights query parameters separately for better readability.


### **Screenshot**
<img width="552" height="265" alt="image" src="https://github.com/user-attachments/assets/e6712566-50b7-48e4-b9e6-fab10a5fd002" />


### **Related Issue**

Closes #38 

