### PR TITLE
QOL-Update: Use System Theme By Default

### DIFF
--- a/apps/webapp/src/components/ui/color-mode.tsx
+++ b/apps/webapp/src/components/ui/color-mode.tsx
@@ -11,7 +11,7 @@ import { TbSun, TbMoon } from 'react-icons/tb';
 export interface ColorModeProviderProps extends ThemeProviderProps {}
 
 export function ColorModeProvider(props: ColorModeProviderProps) {
-  return <ThemeProvider attribute="class" disableTransitionOnChange defaultTheme="light" {...props} />;
+  return <ThemeProvider attribute="class" disableTransitionOnChange defaultTheme="system" {...props} />;
 }
 
 export type ColorMode = 'light' | 'dark';


### PR DESCRIPTION
Simple change in the code for the `color-mode ui component` to pick-up user's theme preferences, rather than defaulting to light mode, for a better QOL.

Form:
<img width="845" height="189" alt="Screenshot 2025-10-13 at 4 15 42 PM" src="https://github.com/user-attachments/assets/260aa4de-cb74-48f6-b7d2-e4e42e97b628" />

To:
<img width="857" height="119" alt="Screenshot 2025-10-13 at 4 43 04 PM" src="https://github.com/user-attachments/assets/f2217628-45d2-4c37-864d-4d75bdacc8d1" />
