### PR TITLE
Fix referrer types output path to include frontend directory

### DIFF
--- a/apps/worker/fetch-referrers.ts
+++ b/apps/worker/fetch-referrers.ts
@@ -122,7 +122,7 @@ export const referrers = ${JSON.stringify({ ...transformedData, ...customReferre
 export const REFERRER_URL_MAP = ${JSON.stringify(referrerUrlMap)};
 export const REFERRER_TYPES = ${JSON.stringify([...Array.from(referrerTypes), 'direct'])};`;
 
-    const outputPathTypes = join(process.cwd(), '..', 'app', 'src', 'consts', 'referrer-types.ts');
+    const outputPathTypes = join(process.cwd(), '..', 'app', 'src', 'frontend', 'consts', 'referrer-types.ts');
     writeFileSync(outputPathTypes, tsContentTypes, 'utf-8');
   } catch (error) {
     console.error('Error fetching referrers:', error);


### PR DESCRIPTION
## Summary
Updated the output path for the generated referrer types file to reflect the correct directory structure in the app.

## Changes
- Modified the `outputPathTypes` path in `apps/worker/fetch-referrers.ts` to include the `frontend` subdirectory
- Changed from: `app/src/consts/referrer-types.ts`
- Changed to: `app/src/frontend/consts/referrer-types.ts`

## Details
This fix ensures that the worker script generates the referrer types TypeScript file to the correct location within the frontend directory structure, aligning with the actual project layout.

https://claude.ai/code/session_01TnnD9aBgzAUYNtwENfcRHy