### PR TITLE
Make project domains editable via settings page

### DIFF
--- a/apps/app/src/backend/routes/projects.ts
+++ b/apps/app/src/backend/routes/projects.ts
@@ -160,29 +160,35 @@ export const projectsRouter = router({
   edit: projectProcedure.input(z.object({ name: projectNameInput, domain: z.string() })).mutation(async (opts) => {
     const {
       input: { name, domain },
-      ctx: { project },
     } = opts;
 
     const projectId = String(opts.ctx.projectId);
     const resolvedDomain = normalizeProjectDomain(domain);
-    const updates: { name?: string; domain?: string } = {};
-
-    if (name !== project.name) {
-      updates.name = name;
-    }
-
-    if (resolvedDomain !== project.domain) {
-      const existingProject = await dbProject.findByDomain({ domain: resolvedDomain });
-      if (existingProject && existingProject.id !== project.id) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'There already exists a project with this domain' });
+    await serializableTransaction(async (client) => {
+      const currentProject = await dbProject.findById(projectId, client);
+      if (!currentProject) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Project not found' });
       }
 
-      updates.domain = resolvedDomain;
-    }
+      const updates: { name?: string; domain?: string } = {};
 
-    if (Object.keys(updates).length > 0) {
-      await dbProject.update(projectId, updates);
-    }
+      if (name !== currentProject.name) {
+        updates.name = name;
+      }
+
+      if (resolvedDomain !== currentProject.domain) {
+        const existingProject = await dbProject.findByDomain({ domain: resolvedDomain, client });
+        if (existingProject && existingProject.id !== currentProject.id) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'There already exists a project with this domain' });
+        }
+
+        updates.domain = resolvedDomain;
+      }
+
+      if (Object.keys(updates).length > 0) {
+        await dbProject.update(projectId, updates, client);
+      }
+    });
 
     return { id: projectId };
   }),

--- a/apps/app/src/backend/routes/projects.ts
+++ b/apps/app/src/backend/routes/projects.ts
@@ -24,6 +24,28 @@ import { vemetric } from '../utils/vemetric-client';
 const projectNameInput = z.string().min(2);
 const projectInput = z.object({ name: projectNameInput, domain: z.string() });
 
+function normalizeProjectDomain(domain: string) {
+  let resolvedDomain: string;
+  try {
+    let url = domain;
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      url = 'https://' + url;
+    }
+
+    resolvedDomain = getNormalizedDomain(url);
+  } catch (err) {
+    logger.error({ err, domain }, 'Domain resolution error');
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid domain' });
+  }
+
+  const splittedDomain = resolvedDomain.split('.');
+  if (splittedDomain.length < 2 || splittedDomain[0].length < 2 || splittedDomain[1].length < 2) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid domain' });
+  }
+
+  return resolvedDomain;
+}
+
 export const projectsRouter = router({
   create: organizationAdminProcedure.input(projectInput).mutation(async (opts) => {
     const {
@@ -39,23 +61,7 @@ export const projectsRouter = router({
       });
     }
 
-    let resolvedDomain: string;
-    try {
-      let url = domain;
-      if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        url = 'https://' + url;
-      }
-
-      resolvedDomain = getNormalizedDomain(url);
-    } catch (err) {
-      logger.error({ err, domain }, 'Domain resolution error');
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid domain' });
-    }
-
-    const splittedDomain = resolvedDomain.split('.');
-    if (splittedDomain.length < 2 || splittedDomain[0].length < 2 || splittedDomain[1].length < 2) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid domain' });
-    }
+    const resolvedDomain = normalizeProjectDomain(domain);
 
     try {
       const project = await serializableTransaction(async (client) => {
@@ -151,14 +157,32 @@ export const projectsRouter = router({
     };
   }),
 
-  edit: projectProcedure.input(z.object({ name: projectNameInput })).mutation(async (opts) => {
+  edit: projectProcedure.input(z.object({ name: projectNameInput, domain: z.string() })).mutation(async (opts) => {
     const {
-      input: { name },
+      input: { name, domain },
+      ctx: { project },
     } = opts;
 
     const projectId = String(opts.ctx.projectId);
+    const resolvedDomain = normalizeProjectDomain(domain);
+    const updates: { name?: string; domain?: string } = {};
 
-    await dbProject.update(projectId, { name });
+    if (name !== project.name) {
+      updates.name = name;
+    }
+
+    if (resolvedDomain !== project.domain) {
+      const existingProject = await dbProject.findByDomain({ domain: resolvedDomain });
+      if (existingProject && existingProject.id !== project.id) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'There already exists a project with this domain' });
+      }
+
+      updates.domain = resolvedDomain;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      await dbProject.update(projectId, updates);
+    }
 
     return { id: projectId };
   }),

--- a/apps/app/src/frontend/components/pages/settings/project/general-tab.tsx
+++ b/apps/app/src/frontend/components/pages/settings/project/general-tab.tsx
@@ -27,6 +27,7 @@ import {
 } from 'react-icons/tb';
 import { CardIcon } from '@/components/card-icon';
 import { CodeBox } from '@/components/code-box';
+import { InfoTip } from '@/components/info-tip';
 import { LoadingImage } from '@/components/loading-image';
 import { DeleteProjectDialog } from '@/components/pages/settings/project/delete-project-dialog';
 import { ExcludedCountriesCard } from '@/components/pages/settings/project/excluded-countries-card';
@@ -35,6 +36,7 @@ import { EmptyState, ErrorState } from '@/components/ui/empty-state';
 import { InputGroup } from '@/components/ui/input-group';
 import { toaster } from '@/components/ui/toaster';
 import { useCurrentOrganization } from '@/hooks/use-current-organization';
+import { authClient } from '@/utils/auth';
 import { getFaviconUrl } from '@/utils/favicon';
 import { trpc } from '@/utils/trpc';
 import { InstallationCard } from './installation-card';
@@ -48,6 +50,7 @@ export const ProjectGeneralTab = (props: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const { organizationId, isAdmin } = useCurrentOrganization();
+  const { refetch: refetchAuth } = authClient.useSession();
 
   const {
     data: projectSettings,
@@ -61,7 +64,7 @@ export const ProjectGeneralTab = (props: Props) => {
       setIsLoading(true);
     },
     onSuccess: async () => {
-      await refetch();
+      await Promise.all([refetch(), refetchAuth()]);
       toaster.create({
         title: 'Project updated successfully',
         type: 'success',
@@ -107,14 +110,20 @@ export const ProjectGeneralTab = (props: Props) => {
     editProject({
       projectId,
       name: projectName,
+      domain,
     });
   };
 
   const [projectName, setProjectName] = useState(projectSettings?.name ?? '');
+  const [domain, setDomain] = useState(projectSettings?.domain ?? '');
 
   useEffect(() => {
     setProjectName(projectSettings?.name ?? '');
   }, [projectSettings?.name]);
+
+  useEffect(() => {
+    setDomain(projectSettings?.domain ?? '');
+  }, [projectSettings?.domain]);
 
   if (error) {
     if (error?.data?.httpStatus === 403) {
@@ -169,19 +178,45 @@ export const ProjectGeneralTab = (props: Props) => {
               </InputGroup>
             </Field.Root>
             <Field.Root>
-              <Field.Label>Domain</Field.Label>
+              <Field.Label>
+                Domain
+                <InfoTip
+                  content={
+                    <>
+                      <Text mb="2">
+                        Be careful, changing the domain will result in a different url for your public dashboard (if
+                        enabled).
+                      </Text>
+                      <Text>
+                        If this domain is wrong, reports like top pages, referrers, and outbound links may look
+                        inaccurate.
+                      </Text>
+                    </>
+                  }
+                  colorPalette="purple"
+                />
+              </Field.Label>
               <InputGroup
                 startElement={
-                  projectSettings.domain.length > 3 ? (
-                    <LoadingImage boxSize="16px" src={getFaviconUrl(projectSettings.domain)} />
+                  domain.length > 3 ? (
+                    <LoadingImage boxSize="16px" src={getFaviconUrl(domain)} />
                   ) : (
                     <Icon as={TbWorldQuestion} boxSize="16px" color="#838383" />
                   )
                 }
                 width="full"
               >
-                <Input placeholder="example.com" value={projectSettings.domain} disabled />
+                <Input
+                  placeholder="example.com"
+                  value={domain}
+                  onChange={(e) => setDomain(e.target.value)}
+                  disabled={isLoading}
+                />
               </InputGroup>
+              <Field.HelperText>
+                We suggest to use the root domain for your project, as Vemetric supports tracking across subdomains.
+                (e.g. landing page on <code>example.com</code>, and your app on <code>dashboard.example.com</code>)
+              </Field.HelperText>
             </Field.Root>
             <Field.Root>
               <Field.Label>Public Token</Field.Label>
@@ -190,7 +225,7 @@ export const ProjectGeneralTab = (props: Props) => {
               </CodeBox>
             </Field.Root>
             <Flex justifyContent="flex-end">
-              <Button type="submit" size="sm">
+              <Button type="submit" size="sm" loading={isLoading}>
                 Save
               </Button>
             </Flex>

--- a/packages/database/src/models/project.ts
+++ b/packages/database/src/models/project.ts
@@ -55,6 +55,7 @@ export const dbProject = {
     id: string,
     data: Partial<{
       name: string;
+      domain: string;
       publicDashboard: boolean;
       eventIcons: Record<string, string>;
       excludedIps: string | null;

--- a/packages/database/src/models/project.ts
+++ b/packages/database/src/models/project.ts
@@ -61,8 +61,9 @@ export const dbProject = {
       excludedIps: string | null;
       excludedCountries: string | null;
     }>,
+    client: DbClient = prismaClient,
   ) =>
-    prismaClient.project.update({
+    client.project.update({
       where: { id },
       data,
     }),


### PR DESCRIPTION
## Description

Users can now edit the domains of their projects on their own.

Closes #45

## Checklist

- [x] I have run the integration tests (`bun run test:integration`)
- [x] I have added tests for new functionality where appropriate

<img width="1360" height="1060" alt="CleanShot 2026-04-03 at 11 00 04@2x" src="https://github.com/user-attachments/assets/34b37304-ae9a-4d8d-8a2b-3f9cb1cb0521" />